### PR TITLE
Add cached docker image net8.0 runtim

### DIFF
--- a/images/windows/toolsets/toolset-2022.json
+++ b/images/windows/toolsets/toolset-2022.json
@@ -272,13 +272,14 @@
         ]
     },
     "docker": {
-        "images": [
-            "mcr.microsoft.com/windows/servercore:ltsc2022",
-            "mcr.microsoft.com/windows/nanoserver:ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022",
-            "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
-        ],
+      "images": [
+        "mcr.microsoft.com/windows/servercore:ltsc2022",
+        "mcr.microsoft.com/windows/nanoserver:ltsc2022",
+        "mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2022",
+        "mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2022",
+        "mcr.microsoft.com/dotnet/framework/runtime:8.0-windowsservercore-ltsc2022",
+        "mcr.microsoft.com/dotnet/framework/sdk:4.8-windowsservercore-ltsc2022"
+      ],
         "components": {
             "docker": "26.1.3",
             "compose": "2.27.1"
@@ -313,10 +314,11 @@
         }
     },
     "dotnet": {
-        "versions": [
-            "6.0",
-            "7.0"
-        ],
+      "versions": [
+        "6.0",
+        "7.0",
+        "8.0"
+      ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion": "nbgv --version" }
         ],


### PR DESCRIPTION
# Description
New tool, Bug fixing, or Improvement?
Please include a summary of the change and which issue is fixed. Also include relevant motivation and context.
**For new tools, please provide total size and installation time.**

<!-- Currently, we can't accept external contributions to macOS source. Please find more details in [CONTRIBUTING.md](CONTRIBUTING.md#macOS) guide -->

#### Related issue:

## Check list
- [X] Related issue / work item is attached
- [x] Tests are written (if applicable)
- [X] Documentation is updated (if applicable)
- [x] Changes are tested and related VM images are successfully generated


#### PR Classification
New feature: Updated toolset to support .NET Framework runtime 8.0 and .NET version 8.0.

#### PR Summary
Updated `toolset-2022.json` to include support for the latest .NET versions.
- `toolset-2022.json`: Added Docker image `mcr.microsoft.com/dotnet/framework/runtime:8.0-windowsservercore-ltsc2022`.
- `toolset-2022.json`: Added .NET version `8.0` updates.
